### PR TITLE
Upgrade actions/upload-artifact and actions/download-artifact from v3 to v4

### DIFF
--- a/.github/workflows/main_rolx-statistics-teams.yml
+++ b/.github/workflows/main_rolx-statistics-teams.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-app
 

--- a/.github/workflows/main_rolx-statistics-teams.yml
+++ b/.github/workflows/main_rolx-statistics-teams.yml
@@ -40,7 +40,7 @@ jobs:
         run: zip release.zip ./* -r
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-app
           path: |


### PR DESCRIPTION
`actions/download-artifact: v3` is deprecated, we need to use v4. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
